### PR TITLE
Update director-configure-blobstore for GCS

### DIFF
--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -21,10 +21,11 @@ To publish:
 
 ### Blobstores
 
-The Go Agent ships with 4 default blobstores:
+The Go Agent ships with 5 default blobstores:
 
 - Local filesystem
 - S3
+- GCS (Google Cloud Storage)
 - DAV
 - Dummy (for testing)
 


### PR DESCRIPTION
BOSH director and bosh-cli have both merged support for using
GCS as a director blobstore. This change documents GCS as
a default blobstore.
cloudfoundry/bosh#1732
cloudfoundry/bosh-cli#238